### PR TITLE
Add native-style image preview with zoom support

### DIFF
--- a/greenlake-companion/Sources/Components/Agenda/TaskTimelineView.swift
+++ b/greenlake-companion/Sources/Components/Agenda/TaskTimelineView.swift
@@ -116,30 +116,12 @@ struct TimelineEntryView: View {
       if !entry.photos.isEmpty {
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 20) {
-            ForEach(entry.photos, id: \.self) { photo in
-              if let url = URL(string: photo.imageUrl) {
-                AsyncImage(url: url) { phase in
-                  switch phase {
-                  case .empty:
-                    ProgressView()
-                      .frame(height: 200)
-                  case .success(let image):
-                    image
-                      .resizable()
-                      .scaledToFit()
-                      .frame(height: 200)
-                      .cornerRadius(10)
-                  case .failure:
-                    Image(systemName: "photo")
-                      .resizable()
-                      .scaledToFit()
-                      .foregroundColor(.gray)
-                      .frame(height: 200)
-                  @unknown default:
-                    EmptyView()
-                  }
-                }
-              }
+            ForEach(Array(entry.photos.enumerated()), id: \.element) { index, photo in
+              TappableAsyncImage(
+                photo: photo,
+                images: entry.photos,
+                selectedIndex: index
+              )
             }
           }
         }

--- a/greenlake-companion/Sources/Components/Shared/ImagePreviewView.swift
+++ b/greenlake-companion/Sources/Components/Shared/ImagePreviewView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ImagePreviewView: View {
+  let images: [Photo]
+  @Binding var isPresented: Bool
+  @StateObject private var viewModel: ImagePreviewViewModel
+
+  init(images: [Photo], selectedIndex: Int, isPresented: Binding<Bool>) {
+    self.images = images
+    self._isPresented = isPresented
+    _viewModel = StateObject(wrappedValue: ImagePreviewViewModel(selectedIndex: selectedIndex))
+  }
+
+  var body: some View {
+    ZStack(alignment: .topTrailing) {
+      Color.black.ignoresSafeArea()
+
+      TabView(selection: $viewModel.currentIndex) {
+        ForEach(Array(images.enumerated()), id: \.element) { index, photo in
+          ZoomableImageView(photo: photo, viewModel: viewModel)
+            .tag(index)
+            .accessibilityLabel("Image \(index + 1) of \(images.count)")
+            .accessibilityHint("Pinch to zoom, swipe left or right to navigate")
+        }
+      }
+      .tabViewStyle(.page(indexDisplayMode: .never))
+      .onChange(of: viewModel.currentIndex) { _, _ in
+        viewModel.resetZoom()
+      }
+
+      Button("Done") {
+        isPresented = false
+      }
+      .padding()
+      .foregroundColor(.white)
+      .accessibilityLabel("Done")
+    }
+    .gesture(
+      DragGesture()
+        .onEnded { value in
+          if value.translation.height > 100 {
+            isPresented = false
+          }
+        }
+    )
+  }
+}

--- a/greenlake-companion/Sources/Components/Shared/TappableAsyncImage.swift
+++ b/greenlake-companion/Sources/Components/Shared/TappableAsyncImage.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct TappableAsyncImage: View {
+  let photo: Photo
+  let images: [Photo]
+  let selectedIndex: Int
+
+  @State private var showingImagePreview = false
+
+  var body: some View {
+    AsyncImage(url: URL(string: photo.thumbnailUrl)) { phase in
+      switch phase {
+      case .empty:
+        ProgressView()
+          .frame(height: 200)
+      case .failure:
+        Image(systemName: "photo")
+          .resizable()
+          .scaledToFit()
+          .foregroundColor(.gray)
+          .frame(height: 200)
+      case .success(let image):
+        image
+          .resizable()
+          .scaledToFit()
+          .frame(height: 200)
+          .cornerRadius(10)
+          .onTapGesture { showingImagePreview = true }
+          .accessibilityLabel("Image \(selectedIndex + 1) of \(images.count)")
+          .accessibilityHint("Double tap to zoom, swipe to navigate")
+          .accessibilityAddTraits(.isButton)
+          .accessibilityAction {
+            showingImagePreview = true
+          }
+      @unknown default:
+        EmptyView()
+          .frame(height: 200)
+      }
+    }
+    .onAppear {
+      preloadNextImage()
+    }
+    .sheet(isPresented: $showingImagePreview) {
+      ImagePreviewView(images: images, selectedIndex: selectedIndex, isPresented: $showingImagePreview)
+    }
+  }
+
+  private func preloadNextImage() {
+    let nextIndex = selectedIndex + 1
+    guard images.indices.contains(nextIndex) else { return }
+    let nextUrlString = images[nextIndex].thumbnailUrl
+    if let url = URL(string: nextUrlString) {
+      let task = URLSession.shared.dataTask(with: url) { _, _, _ in }
+      task.resume()
+    }
+  }
+}

--- a/greenlake-companion/Sources/Components/Shared/ZoomableImageView.swift
+++ b/greenlake-companion/Sources/Components/Shared/ZoomableImageView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct ZoomableImageView: View {
+  let photo: Photo
+  @ObservedObject var viewModel: ImagePreviewViewModel
+
+  @State private var baseScale: CGFloat = 1.0
+  @State private var currentOffset: CGSize = .zero
+
+  var body: some View {
+    AsyncImage(url: URL(string: photo.imageUrl)) { phase in
+      switch phase {
+      case .empty:
+        ProgressView()
+      case .failure:
+        Image(systemName: "photo")
+          .resizable()
+          .scaledToFit()
+          .foregroundColor(.gray)
+      case .success(let image):
+        image
+          .resizable()
+          .scaledToFit()
+      @unknown default:
+        EmptyView()
+      }
+    }
+    .scaleEffect(viewModel.scale)
+    .offset(viewModel.offset)
+    .gesture(zoomAndPanGesture)
+    .onTapGesture(count: 2) {
+      if viewModel.scale > 1 {
+        viewModel.resetZoom()
+        baseScale = 1
+        currentOffset = .zero
+      } else {
+        withAnimation(.spring()) {
+          viewModel.scale = 2
+          baseScale = 2
+        }
+      }
+    }
+    .accessibilityElement()
+    .accessibilityLabel("Preview image")
+    .accessibilityHint("Pinch to zoom, drag to pan")
+  }
+
+  private var zoomAndPanGesture: some Gesture {
+    SimultaneousGesture(
+      MagnificationGesture()
+        .onChanged { value in
+          let newScale = baseScale * value
+          viewModel.scale = min(max(newScale, 1), 5)
+        }
+        .onEnded { _ in
+          baseScale = viewModel.scale
+          if baseScale <= 1 {
+            viewModel.resetZoom()
+            baseScale = 1
+          }
+        },
+      DragGesture()
+        .onChanged { value in
+          if viewModel.scale > 1 {
+            viewModel.offset = CGSize(
+              width: currentOffset.width + value.translation.width,
+              height: currentOffset.height + value.translation.height
+            )
+          }
+        }
+        .onEnded { _ in
+          currentOffset = viewModel.offset
+          if viewModel.scale <= 1 {
+            viewModel.resetZoom()
+            currentOffset = .zero
+          }
+        }
+    )
+  }
+}

--- a/greenlake-companion/Sources/ViewModels/ImagePreviewViewModel.swift
+++ b/greenlake-companion/Sources/ViewModels/ImagePreviewViewModel.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+@MainActor
+class ImagePreviewViewModel: ObservableObject {
+  @Published var currentIndex: Int
+  @Published var scale: CGFloat = 1.0
+  @Published var offset: CGSize = .zero
+
+  init(selectedIndex: Int = 0) {
+    self.currentIndex = selectedIndex
+  }
+
+  func resetZoom() {
+    withAnimation(.spring()) {
+      scale = 1.0
+      offset = .zero
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add ImagePreviewView and ZoomableImageView for fullscreen image preview with pinch-to-zoom and pan
- Implement ImagePreviewViewModel for managing preview state
- Replace AsyncImage usage with TappableAsyncImage enabling tap-to-preview and caching

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68be4820817c832e9c6b14e29ec7d085